### PR TITLE
Adds a random number to the snapshot filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,15 @@ module.exports = function(gulp, opt_options) {
 		return options.artifactName || require(options.packageJsonPath).name;
 	};
 
+	var getRandomNumber = function() {
+		return Math.floor(Math.random() * 10000000000000);
+	};
+
 	var getVersion = function(config) {
 		var version = require(options.packageJsonPath).version;
+		var snapshot = '-SNAPSHOT-' + getRandomNumber();
 
-		return (config && config.snapshot) ? version + '-SNAPSHOT' : version;
+		return (config && config.snapshot) ? version + snapshot : version;
 	};
 
 	gulp.task('clean-maven-dist', function(callback) {


### PR DESCRIPTION
Currently, Liferay Portal does not read .jar files that don't end in numbers. This updates index.js so the filename output will be `{version}-SNAPSHOT-{random number}.*`